### PR TITLE
wait-pr-checksスキルに--fail-fastをデフォルト追加

### DIFF
--- a/.claude/commands/wait-pr-checks.md
+++ b/.claude/commands/wait-pr-checks.md
@@ -6,7 +6,7 @@ description: Wait for PR checks to complete and report results
 
 Monitor GitHub PR checks until they complete or fail:
 
-1. Run `gh pr checks --watch` with `run_in_background: true`
+1. Run `gh pr checks --watch --fail-fast` with `run_in_background: true`
 2. The process completion will be notified automatically - no polling needed
 3. Report the final status to the user
 


### PR DESCRIPTION
## Summary
- `gh pr checks --watch` に `--fail-fast` フラグを追加し、いずれかのチェックが失敗した時点で即座に結果を返すようにした

## Test plan
- [ ] `/wait-pr-checks` 実行時に `--fail-fast` 付きでコマンドが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)