### PR TITLE
Add host config, bump ruby, install tmux, fix setup_macos.sh

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -4,7 +4,8 @@ GOBIN = "{{env.HOME}}/.local/bin"
 [tools]
 node = "22.14.0"
 go = "1.26.1"
-ruby = "3.2.2"
+ruby = "4.0.5"
 
 [settings]
 idiomatic_version_file_enable_tools = ["node"]
+ruby.compile = false

--- a/flake.nix
+++ b/flake.nix
@@ -14,5 +14,10 @@
       pkgs = nixpkgs.legacyPackages.aarch64-darwin;
       modules = [ ./hosts/mh4gf-mac.nix ];
     };
+
+    homeConfigurations.hirotaka-miyagi-001-mac = home-manager.lib.homeManagerConfiguration {
+      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+      modules = [ ./hosts/hirotaka-miyagi-001-mac.nix ];
+    };
   };
 }

--- a/hosts/hirotaka-miyagi-001-mac.nix
+++ b/hosts/hirotaka-miyagi-001-mac.nix
@@ -1,0 +1,12 @@
+{ ... }:
+
+{
+  imports = [ ../home.nix ];
+
+  home.username = "hirotaka.miyagi.001";
+  home.homeDirectory = "/Users/hirotaka.miyagi.001";
+
+  _module.args.dotfilesPath = "/Users/hirotaka.miyagi.001/ghq/github.com/MH4GF/dotfiles";
+
+  home.stateVersion = "25.05";
+}

--- a/modules/git.nix
+++ b/modules/git.nix
@@ -3,35 +3,38 @@
 {
   programs.git = {
     enable = true;
-    userName = "MH4GF";
-    userEmail = "h.miyagi.cnw@gmail.com";
 
-    aliases = {
-      cma = "commit --amend";
-      co = ''!f() { [ $# -eq 0 ] && git checkout $(git branch --sort=-authordate | perl -a -nle '$F[0] ne "*" and print $F[0]' | peco) || git checkout $@; }; f'';
-      com = ''!f() { remote_head=$(git symbolic-ref --quiet refs/remotes/origin/HEAD); remote_head=''${remote_head#refs/remotes/origin/}; git checkout ''${remote_head:-$(git rev-parse --symbolic --verify --quiet main || git rev-parse --symbolic --verify --quiet master)}; git pull; }; f'';
-      comw = ''!f() { \
-        remote_head=$(git symbolic-ref --quiet refs/remotes/origin/HEAD); \
-        remote_head=''${remote_head#refs/remotes/origin/}; \
-        main_branch=''${remote_head:-$(git rev-parse --symbolic --verify --quiet main || git rev-parse --symbolic --verify --quiet master)}; \
-        git checkout $main_branch; \
-        git pull; \
-        merged_branches=$(git branch --merged | grep -v "*" | grep -v "origin/" | sed 's/^[+ ]*//' | tr -d ' '); \
-        git worktree list | tail -n +2 | while read path hash branch; do \
-          branch_name=$(echo $branch | tr -d '[]'); \
-          if echo "$merged_branches" | grep -q "^$branch_name$"; then \
-            git worktree remove "$path" 2>/dev/null || true; \
-          fi; \
-        done; \
-        git branch --merged | grep -v "*" | grep -v "origin/" | sed 's/^[+ ]*//' | xargs -I % git branch -d % 2>/dev/null || true; \
-      }; f'';
-      cp = "cherry-pick";
-      wa = ''!f() { repo_name=$(basename $(git rev-parse --show-toplevel)); branch_dir=$(echo $1 | tr '/' '-'); git worktree add ../''${repo_name}-worktree/''${branch_dir} -b $1; }; f'';
-      war = ''!f() { repo_name=$(basename $(git rev-parse --show-toplevel)); branch_dir=$(echo $1 | tr '/' '-'); git worktree add --track -b $1 ../''${repo_name}-worktree/''${branch_dir} origin/$1; }; f'';
-      wt = "worktree";
-    };
+    settings = {
+      user = {
+        name = "MH4GF";
+        email = "h.miyagi.cnw@gmail.com";
+      };
 
-    extraConfig = {
+      alias = {
+        cma = "commit --amend";
+        co = ''!f() { [ $# -eq 0 ] && git checkout $(git branch --sort=-authordate | perl -a -nle '$F[0] ne "*" and print $F[0]' | peco) || git checkout $@; }; f'';
+        com = ''!f() { remote_head=$(git symbolic-ref --quiet refs/remotes/origin/HEAD); remote_head=''${remote_head#refs/remotes/origin/}; git checkout ''${remote_head:-$(git rev-parse --symbolic --verify --quiet main || git rev-parse --symbolic --verify --quiet master)}; git pull; }; f'';
+        comw = ''!f() { \
+          remote_head=$(git symbolic-ref --quiet refs/remotes/origin/HEAD); \
+          remote_head=''${remote_head#refs/remotes/origin/}; \
+          main_branch=''${remote_head:-$(git rev-parse --symbolic --verify --quiet main || git rev-parse --symbolic --verify --quiet master)}; \
+          git checkout $main_branch; \
+          git pull; \
+          merged_branches=$(git branch --merged | grep -v "*" | grep -v "origin/" | sed 's/^[+ ]*//' | tr -d ' '); \
+          git worktree list | tail -n +2 | while read path hash branch; do \
+            branch_name=$(echo $branch | tr -d '[]'); \
+            if echo "$merged_branches" | grep -q "^$branch_name$"; then \
+              git worktree remove "$path" 2>/dev/null || true; \
+            fi; \
+          done; \
+          git branch --merged | grep -v "*" | grep -v "origin/" | sed 's/^[+ ]*//' | xargs -I % git branch -d % 2>/dev/null || true; \
+        }; f'';
+        cp = "cherry-pick";
+        wa = ''!f() { repo_name=$(basename $(git rev-parse --show-toplevel)); branch_dir=$(echo $1 | tr '/' '-'); git worktree add ../''${repo_name}-worktree/''${branch_dir} -b $1; }; f'';
+        war = ''!f() { repo_name=$(basename $(git rev-parse --show-toplevel)); branch_dir=$(echo $1 | tr '/' '-'); git worktree add --track -b $1 ../''${repo_name}-worktree/''${branch_dir} origin/$1; }; f'';
+        wt = "worktree";
+      };
+
       ghq.root = "~/ghq";
       core = {
         editor = "nvim";

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -5,6 +5,7 @@
     git
     gnupg
     tig
+    tmux
     neovim
     ripgrep
     fd

--- a/setup_macos.sh
+++ b/setup_macos.sh
@@ -50,8 +50,9 @@ echo "📥 Fetching Brewfile..."
 curl -fsSL https://raw.githubusercontent.com/MH4GF/dotfiles/master/Brewfile > ~/.Brewfile
 
 # Brewfileからパッケージをインストール
+# 個別のcask/formula失敗でスクリプト全体が止まらないようにする（set -e対策）
 echo "📦 Installing packages from Brewfile..."
-brew bundle --global
+brew bundle --global || echo "⚠️  一部のBrewfile依存のインストールに失敗しましたが、続行します。"
 
 # 1Password CLIのセットアップ
 echo "🔐 Setting up 1Password CLI..."
@@ -63,10 +64,18 @@ fi
 # dotfilesのクローンとセットアップ
 # 注: SSH鍵は1Passwordで管理。上記でサインイン後、SSH Agentが利用可能
 echo "📥 Setting up dotfiles..."
-ghq get --update git@github.com:MH4GF/dotfiles.git
+# ghqはこの後のHome Managerで導入されるため、ここではまだ無い。素のgitでクローンする
+DOTFILES_DIR="$HOME/ghq/github.com/MH4GF/dotfiles"
+if [[ ! -d "$DOTFILES_DIR" ]]; then
+    mkdir -p "$(dirname "$DOTFILES_DIR")"
+    git clone git@github.com:MH4GF/dotfiles.git "$DOTFILES_DIR"
+fi
 (
-    cd ~/ghq/github.com/MH4GF/dotfiles && ./setup-nix.sh
+    cd "$DOTFILES_DIR" && ./setup-nix.sh
 )
+
+# Home Managerで導入したツール（mise等）を現在のシェルのPATHに載せる
+export PATH="$HOME/.nix-profile/bin:$PATH"
 
 # mise開発ツールのセットアップ
 echo "🛠 Installing development tools with mise..."


### PR DESCRIPTION
## 概要

新しいマシンでのセットアップ中に見つかった対応をまとめたPR。

## 変更点

- **新規ホスト `hosts/hirotaka-miyagi-001-mac.nix` を追加**（`flake.nix` に `homeConfigurations.hirotaka-miyagi-001-mac` も追加）
  - home-manager は `home.username` が `$USER` と一致することをアサートするため、当該マシンのユーザー名・ホームディレクトリ・dotfilesパスに合わせたホストを用意。既存の `mh4gf-mac` はそのまま。
- **ruby を 4.0.5 に更新し `ruby.compile=false` を追加**（`.config/mise/config.toml`）
  - ruby 3.2.2 のソースビルドが `psych`/libyaml 依存で失敗（macOS 26）。最新安定版＋プリコンパイル版に切り替え。
- **tmux をインストール**（`modules/packages.nix`）
  - `modules/tmux.nix` は `.tmux.conf` を配置するだけで tmux 本体を入れていなかったため、パッケージに追加。
- **`setup_macos.sh` のブートストラップ不具合を修正**
  - `brew bundle`: 1つのcask/formula失敗で `set -e` により全体中断していたのを、警告して継続に変更。
  - dotfilesクローン: この時点でまだ入っていない `ghq` に依存していたのを、素の `git clone` に変更。
  - `setup-nix.sh` 実行後に `~/.nix-profile/bin` を PATH に追加し、Home Manager導入の `mise` を後続ステップで見つけられるように。
- **`modules/git.nix` を `programs.git.settings` に移行**
  - `programs.git.{userName,userEmail,aliases,extraConfig}` が非推奨となり `home-manager switch` の度に警告が出ていたため、`settings` 配下へ集約。生成されるgit設定は機能的に不変。

## 補足

- 全コミットGPG署名済み。
- `nix flake check` で両ホスト（mh4gf-mac / hirotaka-miyagi-001-mac）の評価が通ることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)