### PR TITLE
Add homerow cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 cask 'karabiner-elements'
+cask 'homerow'
 cask 'google-chrome'
 cask 'docker-desktop'
 cask '1password'


### PR DESCRIPTION
## 概要

キーボードで画面上のボタンを操作する macOS アプリ **homerow** を追加。

## 変更点

- `Brewfile` に `cask 'homerow'` を追加。
  - homerow はプロプライエタリな macOS GUI アプリで nixpkgs には無いため、他のGUIアプリと同様に Homebrew cask で管理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)